### PR TITLE
Pass shop URL as shop

### DIFF
--- a/ecomailemailmarketing/ecomailemailmarketing.php
+++ b/ecomailemailmarketing/ecomailemailmarketing.php
@@ -39,7 +39,7 @@ class ecomailemailmarketing extends Module
         $this->module_key = '3c90ebaffe6722aece11c7a66bc18bec';
         $this->name = 'ecomailemailmarketing';
         $this->tab = 'emailing';
-        $this->version = '2.2.0';
+        $this->version = '2.2.1';
         $this->author = 'Ecomail';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = ['min' => '1.7.0.0', 'max' => _PS_VERSION_];

--- a/ecomailemailmarketing/lib/api.php
+++ b/ecomailemailmarketing/lib/api.php
@@ -225,7 +225,7 @@ class EcomailAPI
             [
                 'order_id' => 'presta_' . $order['id'],
                 'email' => $customer->email,
-                'shop' => 'prestashop',
+                'shop' => (string) Context::getContext()->shop->getBaseURL(),
                 'amount' => round($order['total_paid_tax_incl'], 2),
                 'tax' => round($order['total_paid_tax_incl'] - $order['total_paid_tax_excl'], 2),
                 'shipping' => round($order['total_shipping'], 2),


### PR DESCRIPTION
This pull request updates the transaction data sent by the `buildTransaction` function to improve shop identification. Instead of using a static shop name, it now dynamically uses the shop's base URL.

- Transaction data now sets the `shop` field to the current shop's base URL using `Context::getContext()->shop->getBaseURL()`, replacing the previous static value `'prestashop'`.